### PR TITLE
Fixing issue using Rails 3.2.6 / ruby 1.9.2p290 and the gem devise 2.1.2

### DIFF
--- a/lib/devise_rpx_connectable/schema.rb
+++ b/lib/devise_rpx_connectable/schema.rb
@@ -1,21 +1,21 @@
-# encoding: utf-8
-require 'devise/schema'
-
-module Devise #:nodoc:
-  module RpxConnectable #:nodoc:
-
-    module Schema
-
-      # Database migration schema for RPX.
-      #
-      def rpx_connectable
-        apply_devise_schema ::Devise.rpx_identifier_field, String, :limit => 255
-      end
-
-    end
-  end
-end
-
-Devise::Schema.module_eval do
-  include ::Devise::RpxConnectable::Schema
-end
+# # encoding: utf-8
+# require 'devise/schema'
+# 
+# module Devise #:nodoc:
+#   module RpxConnectable #:nodoc:
+# 
+#     module Schema
+# 
+#       # Database migration schema for RPX.
+#       #
+#       def rpx_connectable
+#         apply_devise_schema ::Devise.rpx_identifier_field, String, :limit => 255
+#       end
+# 
+#     end
+#   end
+# end
+# 
+# Devise::Schema.module_eval do
+#   include ::Devise::RpxConnectable::Schema
+# end


### PR DESCRIPTION
Here is the error output when trying to generate a migration to add a string rpx_identifier to the user model:
    .rvm/gems/ruby-1.9.2-p290/gems/activesupport-3.2.6/lib/active_support/dependencies.rb:251:in `require': no such file to load -- devise/schema (LoadError)

As you can see in my commit I had to comment out the code in
.rvm/gems/ruby-1.9.2-p290/gems/devise_rpx_connectable-0.2.2/lib/devise_rpx_connectable/schema.rb
to make it work.

I am using using Rails 3.2.6 / ruby 1.9.2p290 and the gem devise 2.1.2.
